### PR TITLE
Add API to batch query service order results

### DIFF
--- a/src/main/java/org/eclipse/xpanse/terra/boot/api/controllers/TerraBootTaskResultApi.java
+++ b/src/main/java/org/eclipse/xpanse/terra/boot/api/controllers/TerraBootTaskResultApi.java
@@ -9,15 +9,26 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.xpanse.terra.boot.models.response.ReFetchResult;
+import org.eclipse.xpanse.terra.boot.models.response.ReFetchState;
 import org.eclipse.xpanse.terra.boot.models.response.TerraformResult;
 import org.eclipse.xpanse.terra.boot.terraform.service.TerraformResultPersistenceManage;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,9 +42,15 @@ public class TerraBootTaskResultApi {
 
     @Resource private TerraformResultPersistenceManage terraformResultPersistenceManage;
 
+    /**
+     * Fetch the stored terraform result.
+     *
+     * @param requestId id of the request
+     * @return terraform result
+     */
     @Tag(
             name = "RetrieveTerraformResult",
-            description = "APIs for manage the task form terra-boot.")
+            description = "APIs to manually fetching task results from terra-boot.")
     @Operation(
             description =
                     "Method to retrieve stored terraform result in case terra-boot "
@@ -43,7 +60,61 @@ public class TerraBootTaskResultApi {
     public ResponseEntity<TerraformResult> getStoredTaskResultByRequestId(
             @Parameter(name = "requestId", description = "id of the request")
                     @PathVariable("requestId")
-                    String requestId) {
+                    @NotNull
+                    UUID requestId) {
         return terraformResultPersistenceManage.retrieveTerraformResultByRequestId(requestId);
+    }
+
+    /**
+     * Batch retrieve stored terraform results.
+     *
+     * @param requestIds list of requestIds
+     * @return list of reFetchResults
+     */
+    @Tag(
+            name = "RetrieveTerraformResult",
+            description = "APIs to manually fetching task results from terra-boot.")
+    @Operation(description = "Method to batch retrieve stored terraform result from terra-boot.")
+    @PostMapping(value = "/results/batch", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public List<ReFetchResult> getBatchTaskResults(
+            @Parameter(description = "List of request IDs")
+                    @RequestBody
+                    @NotEmpty(message = "Request IDs list cannot be empty")
+                    List<UUID> requestIds) {
+        if (CollectionUtils.isEmpty(requestIds)) {
+            throw new IllegalArgumentException("requestIds cannot be empty.");
+        }
+        List<ReFetchResult> reFetchResults = new ArrayList<>();
+        requestIds.forEach(
+                requestId -> {
+                    try {
+                        ResponseEntity<TerraformResult> result =
+                                terraformResultPersistenceManage.retrieveTerraformResultByRequestId(
+                                        requestId);
+                        if (result.getStatusCode() == HttpStatus.OK
+                                && Objects.nonNull(result.getBody())) {
+                            reFetchResults.add(
+                                    ReFetchResult.builder()
+                                            .terraformResult(result.getBody())
+                                            .state(ReFetchState.OK)
+                                            .build());
+                        } else {
+                            reFetchResults.add(
+                                    ReFetchResult.builder()
+                                            .state(
+                                                    ReFetchState
+                                                            .RESULT_ALREADY_RETURNED_OR_REQUEST_ID_INVALID)
+                                            .build());
+                        }
+                    } catch (Exception e) {
+                        reFetchResults.add(
+                                ReFetchResult.builder()
+                                        .state(
+                                                ReFetchState
+                                                        .RESULT_ALREADY_RETURNED_OR_REQUEST_ID_INVALID)
+                                        .build());
+                    }
+                });
+        return reFetchResults;
     }
 }

--- a/src/main/java/org/eclipse/xpanse/terra/boot/models/exceptions/TerraformApiExceptionHandler.java
+++ b/src/main/java/org/eclipse/xpanse/terra/boot/models/exceptions/TerraformApiExceptionHandler.java
@@ -27,6 +27,16 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @RestControllerAdvice
 public class TerraformApiExceptionHandler {
 
+    /** Exception handler for IllegalArgumentException. */
+    @ExceptionHandler({IllegalArgumentException.class})
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    @ResponseBody
+    public Response handleIllegalArgumentException(IllegalArgumentException ex) {
+        log.error("handleIllegalArgumentException: ", ex);
+        return Response.errorResponse(
+                ResultType.UNPROCESSABLE_ENTITY, Collections.singletonList(ex.getMessage()));
+    }
+
     /** Exception handler for TerraformExecutorException. */
     @ExceptionHandler({TerraformExecutorException.class})
     @ResponseStatus(HttpStatus.BAD_GATEWAY)

--- a/src/main/java/org/eclipse/xpanse/terra/boot/models/response/ReFetchResult.java
+++ b/src/main/java/org/eclipse/xpanse/terra/boot/models/response/ReFetchResult.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.terra.boot.models.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+
+/** Data model for re-fetching order result. */
+@Data
+@Builder
+public class ReFetchResult {
+
+    @NotNull
+    @Schema(description = "State of the re-fetching request.")
+    private ReFetchState state;
+
+    @Schema(description = "Result of the service order executed by terraform.")
+    private TerraformResult terraformResult;
+}

--- a/src/main/java/org/eclipse/xpanse/terra/boot/models/response/ReFetchState.java
+++ b/src/main/java/org/eclipse/xpanse/terra/boot/models/response/ReFetchState.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.terra.boot.models.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.commons.lang3.StringUtils;
+
+/** ReFetch state for the REST API. */
+public enum ReFetchState {
+    OK("OK"),
+    RESULT_ALREADY_RETURNED_OR_REQUEST_ID_INVALID("ResultAlreadyReturnedOrRequestIdInvalid");
+
+    private final String state;
+
+    ReFetchState(String state) {
+        this.state = state;
+    }
+
+    /** For ReFetchState deserialize. */
+    @JsonValue
+    public String toValue() {
+        return this.state;
+    }
+
+    /** For ReFetchState serialize. */
+    @JsonCreator
+    public ReFetchState getByValue(String name) {
+        for (ReFetchState state : values()) {
+            if (StringUtils.equalsIgnoreCase(state.state, name)) {
+                return state;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -5,8 +5,8 @@
 terra.boot.webhook.hmac.request.signing.key=1c30e4b1fad574f88572e25d0da03f34365f4ae92eda22bfd3a8c53cb5102f27
 authorization.server.endpoint=http://localhost:8088
 # set authorization client id for api
-authorization.api.client.id=302705713103306755
+authorization.api.client.id=306935357671276547
 # set authorization client secret for api
-authorization.api.client.secret=8cCu3PTpLPz3kBfB5aFCX32IdhIlmPZCic5aFNHCR6na8TW1ZIhFOR3v1s3GVBYx
+authorization.api.client.secret=AhOc8tsQv8nzk5diQx4EscdoEUKkVfTLM8R06mw7xZ5HIWViiOkfBK6VEWaRCXPR
 # set authorization client id for swagger-ui
-authorization.swagger.ui.client.id=302705713271078915
+authorization.swagger.ui.client.id=306935358862458883

--- a/src/test/java/org/eclipse/xpanse/terra/boot/terraform/tool/TerraformInstallerTest.java
+++ b/src/test/java/org/eclipse/xpanse/terra/boot/terraform/tool/TerraformInstallerTest.java
@@ -21,10 +21,10 @@ import org.springframework.boot.test.context.SpringBootTest;
             TerraformVersionsFetcher.class,
             SystemCmd.class
         },
-        properties = {"support.default.terraform.versions.only=false"})
+        properties = {"support.default.terraform.versions.only=true"})
 class TerraformInstallerTest {
 
-    @Value("${terraform.default.supported.versions:1.6.0,1.7.0,1.8.0,1.9.0}")
+    @Value("${terraform.default.supported.versions:1.6.0,1.7.0,1.8.0,1.9.0,1.10.0}")
     private String terraformVersions;
 
     @Resource private TerraformInstaller installer;
@@ -42,7 +42,7 @@ class TerraformInstallerTest {
         String terraformPath = installer.getExecutorPathThatMatchesRequiredVersion(requiredVersion);
         assertEquals("terraform", terraformPath);
 
-        String requiredVersion1 = "= 1.6.0";
+        String requiredVersion1 = "= 1.7.0";
         String[] operatorAndNumber1 =
                 versionHelper.getOperatorAndNumberFromRequiredVersion(requiredVersion1);
         String terraformPath1 =
@@ -51,7 +51,7 @@ class TerraformInstallerTest {
                 versionHelper.checkIfExecutorIsMatchedRequiredVersion(
                         new File(terraformPath1), operatorAndNumber1[0], operatorAndNumber1[1]));
 
-        String requiredVersion2 = "<= v1.5.9";
+        String requiredVersion2 = "<= v1.6.0";
         String[] operatorAndNumber2 =
                 versionHelper.getOperatorAndNumberFromRequiredVersion(requiredVersion2);
         String terraformPath2 =
@@ -60,7 +60,7 @@ class TerraformInstallerTest {
                 versionHelper.checkIfExecutorIsMatchedRequiredVersion(
                         new File(terraformPath2), operatorAndNumber2[0], operatorAndNumber2[1]));
 
-        String requiredVersion3 = ">= v1.9.5";
+        String requiredVersion3 = ">= v1.9.0";
         String[] operatorAndNumber3 =
                 versionHelper.getOperatorAndNumberFromRequiredVersion(requiredVersion3);
         String terraformPath3 =


### PR DESCRIPTION
Fixed https://github.com/eclipse-xpanse/xpanse/issues/2387
Related to https://github.com/eclipse-xpanse/tofu-maker/pull/126
Batch query results by orderIds:
![image](https://github.com/user-attachments/assets/cab1b099-afec-4d99-8991-2958235ed4b0)
