### PR TITLE
Fix always deploying in progress when result file not found

### DIFF
--- a/src/main/java/org/eclipse/xpanse/terra/boot/api/controllers/TerraBootTaskResultApi.java
+++ b/src/main/java/org/eclipse/xpanse/terra/boot/api/controllers/TerraBootTaskResultApi.java
@@ -9,8 +9,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -56,7 +54,6 @@ public class TerraBootTaskResultApi {
     public ReFetchResult getStoredTaskResultByRequestId(
             @Parameter(name = "requestId", description = "id of the request")
                     @PathVariable("requestId")
-                    @NotNull
                     UUID requestId) {
         return terraformResultPersistenceManage.retrieveTerraformResultByRequestId(requestId);
     }
@@ -73,9 +70,7 @@ public class TerraBootTaskResultApi {
     @Operation(description = "Method to batch retrieve stored terraform result from terra-boot.")
     @PostMapping(value = "/results/batch", consumes = MediaType.APPLICATION_JSON_VALUE)
     public List<ReFetchResult> getBatchTaskResults(
-            @Parameter(description = "List of request IDs")
-                    @RequestBody
-                    @NotEmpty(message = "Request IDs list cannot be empty")
+            @Parameter(description = "List of request IDs", required = true) @RequestBody
                     List<UUID> requestIds) {
         if (CollectionUtils.isEmpty(requestIds)) {
             throw new IllegalArgumentException("requestIds cannot be empty.");

--- a/src/main/java/org/eclipse/xpanse/terra/boot/terraform/service/TerraformResultPersistenceManage.java
+++ b/src/main/java/org/eclipse/xpanse/terra/boot/terraform/service/TerraformResultPersistenceManage.java
@@ -107,7 +107,7 @@ public class TerraformResultPersistenceManage {
     }
 
     private boolean isDeployingInProgress(UUID requestId) {
-        String workspace = scriptsHelper.buildTaskWorkspace(requestId.toString());
+        File workspace = scriptsHelper.getTaskWorkspace(requestId.toString());
         File tfLockFile = new File(workspace, TF_LOCK_FILE_NAME);
         return tfLockFile.exists() && tfLockFile.isFile();
     }

--- a/src/main/java/org/eclipse/xpanse/terra/boot/terraform/service/TerraformScriptsHelper.java
+++ b/src/main/java/org/eclipse/xpanse/terra/boot/terraform/service/TerraformScriptsHelper.java
@@ -53,12 +53,22 @@ public class TerraformScriptsHelper {
      * @return workspace path for the Terraform deployment task.
      */
     public String buildTaskWorkspace(String taskId) {
-        File ws = new File(getModuleParentDirectoryPath(), taskId);
+        File ws = getTaskWorkspace(taskId);
         if (!ws.exists() && !ws.mkdirs()) {
             throw new TerraformExecutorException(
                     "Create task workspace failed, File path not created: " + ws.getAbsolutePath());
         }
         return ws.getAbsolutePath();
+    }
+
+    /**
+     * Get the workspace path for the Terraform deployment task.
+     *
+     * @param taskId id of the Terraform deployment task.
+     * @return path of the workspace.
+     */
+    public File getTaskWorkspace(String taskId) {
+        return new File(getModuleParentDirectoryPath(), taskId);
     }
 
     /**


### PR DESCRIPTION
 Fixed https://github.com/eclipse-xpanse/xpanse/issues/2387
Before repair, called the service with a random UUID:
![image](https://github.com/user-attachments/assets/70804681-3a79-4121-91b3-a39ac489975d)

After repair, called the service with a random UUID:
![image](https://github.com/user-attachments/assets/f78b6985-1445-4789-96ba-b4f4c69abe52)
